### PR TITLE
allow more than 9999 session and prevent the cpu from being eaten

### DIFF
--- a/SomtodayProxy/SessionManager.cs
+++ b/SomtodayProxy/SessionManager.cs
@@ -52,7 +52,7 @@ namespace SomtodayProxy
             string vanityUrl;
             do
             {
-                vanityUrl = Constants.BaseVanitUrl + new Random().Next(0, 9999).ToString("D4");
+                vanityUrl = Constants.BaseVanitUrl + new Random().Next(0, (int) Math.Pow(10, Math.Max((int) Math.Log10(_sessions.Count * 1.1) + 1, 4)) - 1).ToString($ "D{Math.Max((int)Math.Log10(_sessions.Count*1.1) + 1, 4)}");
             } while (_sessions.ContainsKey(vanityUrl));
 
             return vanityUrl;


### PR DESCRIPTION
instead of setting your house on fire when more than 9999 people login at once, consider not doing that instead (by just giving a slightly longer vanityUrl)

(also, my formatter deleted some random spaces you left on line 21 and 26)